### PR TITLE
Add fraud API schema and documentation blueprint

### DIFF
--- a/docs/api-docs-information-architecture.md
+++ b/docs/api-docs-information-architecture.md
@@ -1,0 +1,73 @@
+# Documentation Information Architecture
+
+This navigation blueprint structures the Sentinel Fraud Decisioning API documentation to help external integrators and internal stakeholders discover information quickly. The left navigation groups content by the primary jobs developers need to accomplish.
+
+## Overview
+- **Welcome & Concepts**
+  - Overview
+  - Key Concepts (risk scoring lifecycle, decision outcomes)
+  - Privacy & Data Handling
+  - Compliance & Certifications
+- **Getting Access**
+  - Environments & Base URLs
+  - Authentication (OAuth 2.0, API keys, mTLS)
+  - Rate Limits & Quotas
+  - SLAs & Support
+
+## Build
+- **Quickstarts**
+  - 3-Minute Quickstart
+  - cURL Walkthrough
+  - SDK Quickstarts
+    - Node.js
+    - Python
+    - Java
+    - Go
+  - Postman/Insomnia Collections
+- **API Reference**
+  - Score in Real Time (`POST /v1/score`)
+  - Batch Score (`POST /v1/batch/score`)
+  - Retrieve Decision (`GET /v1/events/{id}`)
+  - Health Check (`GET /v1/health`)
+  - Schema (`GET /v1/schema`)
+  - Error Catalog
+- **Guides**
+  - Mapping Decisions to Product Flows
+  - Risk Threshold Tuning
+  - Sandbox vs Production Playbook
+  - Webhooks & Callbacks
+  - Secure Data Handling (Hashing, Tokenization)
+  - Observability & Traceability
+
+## Test & Validate
+- **Playground**
+  - Inline Console
+  - Mock Datasets
+  - Decision Explorer (filter by risk level)
+- **Certification**
+  - Checklist for Go-Live
+  - Incident Response Procedures
+
+## Maintain & Evolve
+- **Changelog**
+  - Release Notes
+  - Deprecation Notices (180-day policy)
+- **Roadmap & Feedback**
+  - Upcoming Changes
+  - Feature Request Portal
+- **Support**
+  - Troubleshooting
+  - Contact Channels
+  - Operational Status Page
+
+## Resources
+- **Download Center**
+  - OpenAPI Specification
+  - SDKs & Helper Libraries
+  - Sample Payloads & Test Data
+- **Compliance Library**
+  - GDPR Statement
+  - Privacy Impact Assessment Summary
+  - Data Processing Agreements
+
+> The left navigation is supplemented by contextual tabs (e.g., "Parameters", "Responses", "SDKs") on endpoint pages to minimize scroll depth while still exposing critical integration details.

--- a/docs/api-schema-overview.md
+++ b/docs/api-schema-overview.md
@@ -1,0 +1,108 @@
+# Sentinel Fraud Decisioning API — Schema & Documentation Blueprint
+
+This document distills requirements for the external-facing API program, combining schema design, security posture, developer experience standards, and operational commitments.
+
+## Purpose & Target Personas
+- **Purpose:** Enable partners (banks, fintechs, wallets, public sector portals) to submit minimal transaction metadata and receive fraud decisions within milliseconds while safeguarding privacy.
+- **Primary users:**
+  - External: Backend developers, solution architects, fraud platform engineers
+  - Internal: API product owner, technical writers, support/solutions engineers, compliance teams
+
+## Core Endpoints (v1)
+| Method & Path | Description | SLA | Notes |
+| --- | --- | --- | --- |
+| `POST /v1/score` | Real-time scoring of a single transaction | `<3 ms p95` production, `10–30 ms` sandbox | Requires OAuth scope `score` or API key with scoring permission |
+| `POST /v1/batch/score` | Async scoring for arrays or NDJSON files | First decision manifest within 2 minutes for ≤10k records | Returns `202 Accepted` receipt; supports callbacks |
+| `GET /v1/events/{id}` | Retrieve historical decision or batch manifest | 90-day retention (prod), 7-day (sandbox) | Accepts `txn_id`, `trace_id`, or `batch_id` |
+| `GET /v1/health` | Current service status & latency metrics | No auth required | Useful for monitoring integration |
+| `GET /v1/schema` | Machine-readable OpenAPI / JSON Schema | No auth required | Versioned per release; supports automation |
+
+Full machine-readable spec: [`openapi.yaml`](./openapi.yaml).
+
+## Request & Response Contracts
+### Request (Score)
+Minimal, privacy-first payloads with hashed identifiers.
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `txn_id` | string | ✔ | Client transaction identifier |
+| `timestamp` | ISO 8601 | ✔ | UTC timestamp |
+| `amount.value` | number | ✔ | Major currency units |
+| `amount.currency` | string | ✔ | ISO 4217 |
+| `context` | enum | ✔ | `transfer`, `card`, `invoice`, `defi_sign`, `wallet_send`, `other` |
+| `counterparty_id` | string | ✔ | Hashed/tokenized ID |
+| `payer_id` | string | ✔ | Hashed/tokenized ID |
+| `device.device_id` | string | ✔ | Persistent hashed device token |
+| `device.ip_partial` | string | ▢ | Subnet or masked IP |
+| `device.geo_coarse` | string | ▢ | Country or region |
+| `signals` | object | ▢ | Behavioral metrics (flex schema) |
+| `channel` | enum | ✔ | `web`, `ios`, `android`, `api` |
+
+### Response (Score)
+Structured outputs to power deterministic flows.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `risk_score` | 0–100 integer | Higher = riskier |
+| `risk_level` | enum | `low`, `medium`, `high` mapped in docs |
+| `decision` | enum | `allow`, `challenge`, `block` |
+| `explanations[]` | string | Human-readable reasons (max 5) |
+| `confidence` | 0–1 float | Model confidence |
+| `policy_triggered[]` | string | Rule/policy identifiers |
+| `trace_id` | string | Correlate with support |
+| `latency_ms` | integer | Observed processing time |
+
+## Authentication & Security Controls
+- **OAuth 2.0 client credentials** with `score` and `events` scopes.
+- **API keys** scoped by environment; keys are generated per app with role-based management.
+- **Mutual TLS** optional for enterprise tenants; certificates rotated annually.
+- **Rate limits**: 100 RPS burst / 10k RPM sustained per key by default. Document custom tiers and contact path for increases.
+- **PII minimization**: Require hashing/tokenization for payer and counterparty IDs; highlight do-not-send fields.
+- **Logging & traceability**: Provide `trace_id` on every response and require clients to log for audits.
+
+## Developer Experience Standards
+- **OpenAPI 3.1** spec with examples per context (transfer, card, etc.). Auto-generate SDKs from spec.
+- **Quickstarts** for cURL and languages (Node, Python, Java, Go) plus Postman collection.
+- **Interactive Playground** using mock data with prefilled payloads and inline schema validation.
+- **Error catalog** enumerating codes, HTTP status, description, remediation tips.
+- **Versioning**: URI-based (`/v1`). Deprecations announced ≥180 days before enforcement; changelog entries link to migration steps.
+- **SLAs**: Document latency, availability, and support response times (e.g., P1 within 30 minutes).
+- **Compliance**: Dedicated page covering privacy-by-design, GDPR/CCPA posture, data retention, and audit readiness.
+
+## Error Catalog Snapshot
+| HTTP | Code | Message | Resolution |
+| --- | --- | --- | --- |
+| 400 | `INVALID_CONTEXT` | Unsupported `context` value | Correct enum value |
+| 401 | `UNAUTHORIZED` | Missing/invalid credentials | Refresh token or rotate API key |
+| 403 | `INSUFFICIENT_SCOPE` | Key lacks required scope | Request scope upgrade |
+| 413 | `PAYLOAD_TOO_LARGE` | Batch exceeds limit | Split batch or use file mode |
+| 429 | `RATE_LIMITED` | Rate limit exceeded | Honor `Retry-After`, contact support |
+| 500 | `INTERNAL_ERROR` | Unexpected error | Retry with backoff; provide `trace_id` |
+
+## Sandbox to Production Journey
+1. **Discover**: Developer reads Overview, privacy guidance, and 3-minute Quickstart.
+2. **Authenticate**: Generate sandbox API key via portal; highlight OAuth option for enterprises.
+3. **First Call**: Execute copy-paste cURL example; Playground mirrors request for instant feedback.
+4. **Integrate**: Swap to SDK sample; implement decision mapping (allow/challenge/block) using recommended thresholds.
+5. **Tune**: Consult risk tuning guide; configure notifications on high-risk decisions.
+6. **Go-live**: Submit production access request, complete checklist, review incident procedures.
+7. **Maintain**: Subscribe to changelog RSS/email; monitor deprecation notices.
+
+## Operational Policies
+- **Latency**: `<3 ms p95` production, `10–30 ms` sandbox; publish real-time metrics on status page.
+- **Availability**: 99.95% monthly target. Document failover procedures.
+- **Support**: 24/7 for critical issues, 8x5 for sandbox queries.
+- **Deprecation**: Minimum 180-day notice; dual-write period recommended.
+- **Data retention**: Sandbox decisions 7 days, production 90 days (configurable up to 180 for enterprise).
+
+## Compliance & Privacy Checklist
+- Data minimization (hash personally identifiable identifiers).
+- Encryption in transit (TLS 1.2+ with optional mTLS) and at rest (AES-256).
+- GDPR readiness: Data processing agreements, audit logs, regional data residency options (EU, US).
+- Incident response: Documented runbooks, with SLA commitments for partner notification.
+
+## Related Assets
+- [Documentation Information Architecture](./api-docs-information-architecture.md)
+- [Content Templates](./content-templates.md)
+- [Example Payload Cards](./example-payloads.md)
+- [Visual Diagrams](./diagrams.md)

--- a/docs/content-templates.md
+++ b/docs/content-templates.md
@@ -1,0 +1,124 @@
+# Content Component Templates
+
+Use these templates to maintain consistency across endpoint references, tutorials, and conceptual documentation.
+
+## Endpoint Reference Page Template
+
+```
+# {HTTP METHOD} {PATH}
+
+**Use this when:** {short scenario statement}
+
+## Summary
+Concise description of business value and response timing.
+
+## Authentication
+- Supported methods: {OAuth2, API key, mTLS}
+- Required scopes: {scope list}
+
+## Request
+### Path Parameters
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+
+### Query Parameters *(if applicable)*
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+
+### Headers
+| Name | Required | Description |
+| --- | --- | --- |
+
+### Body Schema
+Embed auto-generated schema block from OpenAPI; include privacy callouts.
+
+### Example Requests
+Tabs: cURL · Node.js · Python · Java · Go
+
+```
+curl --request POST https://{env}.api.example.com/v1/score \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{ ... }'
+```
+
+## Response
+### Success (200)
+- Decision flow copy (e.g., "Expect latency under 3 ms p95 in production").
+- JSON example with field-level annotations.
+
+### Errors
+Reference error catalog with inline excerpts for the most common codes.
+
+### Next Steps
+Link to relevant guides, SDK helpers, and changelog entries.
+```
+
+## Quickstart Template (3-5 minute)
+
+```
+# Quickstart: {Context}
+
+## Goal
+State the outcome in plain language.
+
+## Prerequisites
+- Sandbox account with {role}
+- API key or OAuth client
+- Tooling (CLI, language runtime)
+
+## Step 1 — Get Credentials
+Provide code snippet or UI steps.
+
+## Step 2 — Make Your First Call
+Show terminal output + screenshot of Playground response (optional).
+
+## Step 3 — Interpret the Decision
+Explain risk levels and suggested product actions.
+
+## Step 4 — Move to Staging
+Highlight environment switch, secrets storage, and logging guidance.
+
+## Troubleshooting
+Bulleted list of common issues and fixes.
+```
+
+## Concept / Guide Template
+
+```
+# {Concept Title}
+
+## Why it matters
+Business outcome framing.
+
+## How it works
+Sequence diagram or numbered flow.
+
+## Implementation Checklist
+- [ ] Step
+- [ ] Step
+
+## Best Practices
+Bullet list with citations to compliance/privacy guidance.
+
+## Related Resources
+Links to API reference, tutorials, and external regulations.
+```
+
+## Changelog Entry Template
+
+```
+## {Date} — {Change Title}
+
+### Added
+- Bullet list
+
+### Changed
+- Bullet list
+
+### Deprecated / Removed
+- Bullet list with deprecation timelines (>= 180 days notice).
+
+### Impact & Action
+Plain-language guidance for partners, with links to migration steps.
+```

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,0 +1,48 @@
+# Visual Diagrams
+
+Use these Mermaid diagrams in the documentation platform to visualize critical flows.
+
+## Real-Time Scoring Sequence
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Client
+  participant API as Sentinel API Gateway
+  participant Engine as Risk Engine
+  participant Policies as Policy Service
+
+  Client->>API: POST /v1/score (transaction metadata)
+  API->>Engine: Normalize & forward payload
+  Engine->>Policies: Evaluate rules & ML models
+  Policies-->>Engine: Policy hits & model score
+  Engine-->>API: Decision (score, explanations, trace_id)
+  API-->>Client: 200 OK (latency <3 ms p95)
+  API-)Observability: Emit trace/span for audit
+```
+
+## Authentication Flow
+
+```mermaid
+flowchart LR
+  A[Client App] -->|Client credentials| B(IdP / OAuth Server)
+  B -->|Access token| A
+  A -->|mTLS handshake (optional)| C[Sentinel API]
+  A -->|Bearer token or X-Api-Key| C
+  C --> D[Scope & rate limit check]
+  D --> E[Request routed to service]
+  D --> F[429 if burst exceeded]
+```
+
+## Rate Limit Explainer
+
+```mermaid
+stateDiagram-v2
+  [*] --> WithinLimits
+  WithinLimits --> BurstWindowExceeded: > 100 req / sec
+  BurstWindowExceeded --> Throttled: if sustained window also exceeded
+  BurstWindowExceeded --> WithinLimits: after short cooldown
+  Throttled --> WithinLimits: after Retry-After expires
+  WithinLimits --> SustainedLimitExceeded: > 10k req / min
+  SustainedLimitExceeded --> Throttled
+```

--- a/docs/example-payloads.md
+++ b/docs/example-payloads.md
@@ -1,0 +1,95 @@
+# Example Payload Cards
+
+These copy-ready cards blend technical fidelity with accessible explanations for partner developers and product stakeholders.
+
+---
+**Scenario:** New wallet-to-wallet transfer
+
+```
+POST /v1/score
+Content-Type: application/json
+```
+
+```json
+{
+  "txn_id": "txn_wallet_5521",
+  "timestamp": "2024-05-14T10:05:11Z",
+  "amount": { "currency": "USD", "value": 180.00 },
+  "context": "wallet_send",
+  "counterparty_id": "hash_wallet_B9",
+  "payer_id": "hash_wallet_A7",
+  "device": {
+    "device_id": "hash_device_web_443",
+    "ip_partial": "198.51.100.0/27",
+    "geo_coarse": "US-TX"
+  },
+  "signals": {
+    "velocity_24h_bucket": "1",
+    "keystroke_variance": 0.31
+  },
+  "channel": "web"
+}
+```
+
+> **Why it matters:** Use when a customer sends funds to a new wallet. Latency target: `<3 ms p95` in production.
+
+---
+**Scenario:** Card-not-present ecommerce checkout
+
+```
+POST /v1/score
+Content-Type: application/json
+```
+
+```json
+{
+  "txn_id": "txn_card_8821",
+  "timestamp": "2024-05-14T19:45:03Z",
+  "amount": { "currency": "GBP", "value": 79.90 },
+  "context": "card",
+  "counterparty_id": "hash_merchant_212",
+  "payer_id": "hash_cardholder_557",
+  "device": {
+    "device_id": "hash_device_ios_19",
+    "ip_partial": "203.0.113.128/28",
+    "geo_coarse": "GB-LND"
+  },
+  "signals": {
+    "past_reversal_rate": 0.18,
+    "velocity_24h_bucket": "6-9"
+  },
+  "channel": "ios"
+}
+```
+
+> **Decision example:** `risk_level: medium`, `decision: challenge` with explanations `"new device fingerprint"`, `"velocity spike"`.
+
+---
+**Scenario:** Batch scoring via inline array
+
+```
+POST /v1/batch/score
+Content-Type: application/json
+```
+
+```json
+{
+  "batch_id": "batch_midday_1405",
+  "mode": "inline",
+  "transactions": [
+    { "txn_id": "txn_001", "timestamp": "2024-05-14T12:00:00Z", "amount": { "currency": "USD", "value": 980.0 }, "context": "transfer", "counterparty_id": "hash_vendor_1", "payer_id": "hash_corp_44", "device": { "device_id": "hash_srv_01", "ip_partial": "192.0.2.0/28", "geo_coarse": "US-NY" }, "channel": "api" },
+    { "txn_id": "txn_002", "timestamp": "2024-05-14T12:00:05Z", "amount": { "currency": "USD", "value": 5120.0 }, "context": "invoice", "counterparty_id": "hash_vendor_9", "payer_id": "hash_corp_44", "device": { "device_id": "hash_srv_02", "ip_partial": "192.0.2.0/28", "geo_coarse": "US-NY" }, "channel": "api" }
+  ]
+}
+```
+
+> **What to expect:** Response `202 Accepted` with `callback_url` or `polling_token`. SLA: results posted within 2 minutes for ≤10k records.
+
+---
+**Scenario:** Retrieve historical decision
+
+```
+GET /v1/events/{id}
+```
+
+> Provide `txn_id`, `trace_id`, or `batch_id` to pull audit-ready explanations and policy triggers.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,648 @@
+openapi: 3.1.0
+info:
+  title: Sentinel Fraud Decisioning API
+  version: "1.0.0"
+  summary: Real-time fraud risk scoring and decisioning for financial platforms.
+  description: |
+    The Sentinel Fraud Decisioning API provides synchronous and batch endpoints to evaluate
+    transaction risk in milliseconds, enabling banks, fintechs, wallets, and government portals
+    to prevent fraud while preserving customer experience.
+  termsOfService: https://example.com/terms
+  contact:
+    name: Fraud Platform Support
+    url: https://example.com/support
+    email: support@example.com
+  license:
+    name: Proprietary
+    url: https://example.com/license
+servers:
+  - url: https://sandbox.api.example.com
+    description: Sandbox environment with relaxed rate limits and mock data.
+  - url: https://api.example.com
+    description: Production environment with live scoring.
+tags:
+  - name: Scoring
+    description: Real-time and batch transaction risk scoring.
+  - name: Events
+    description: Fetch previously scored transaction decisions.
+  - name: Operations
+    description: Health checks and schema retrieval.
+paths:
+  /v1/score:
+    post:
+      tags: [Scoring]
+      summary: Score a single transaction in real time.
+      description: |
+        Submits transaction metadata for immediate risk scoring. Responses are returned in
+        milliseconds with structured guidance on whether to allow, challenge, or block the
+        transaction.
+      operationId: scoreTransaction
+      security:
+        - OAuth2ClientCredentials: []
+        - ApiKeyAuth: []
+        - MutualTLS: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScoreRequest'
+            examples:
+              webTransfer:
+                summary: Web transfer with new payee
+                value:
+                  txn_id: "txn_1234567890"
+                  timestamp: "2024-05-14T16:21:00Z"
+                  amount:
+                    currency: "USD"
+                    value: 2450.75
+                  context: transfer
+                  counterparty_id: "hash_payee_001"
+                  payer_id: "hash_customer_123"
+                  device:
+                    device_id: "hash_device_abc"
+                    ip_partial: "203.0.113.0/24"
+                    geo_coarse: "US-CA"
+                  signals:
+                    keystroke_variance: 0.82
+                    velocity_24h_bucket: "3-5"
+                  channel: web
+              mobileCard:
+                summary: Mobile card transaction with elevated velocity
+                value:
+                  txn_id: "txn_9876543210"
+                  timestamp: "2024-05-14T16:25:43Z"
+                  amount:
+                    currency: "EUR"
+                    value: 59.99
+                  context: card
+                  counterparty_id: "hash_merchant_xyz"
+                  payer_id: "hash_cardholder_987"
+                  device:
+                    device_id: "hash_device_ios"
+                    ip_partial: "198.51.100.0/28"
+                    geo_coarse: "DE-BE"
+                  signals:
+                    past_reversal_rate: 0.12
+                    velocity_24h_bucket: "10+"
+                  channel: ios
+      responses:
+        '200':
+          description: Risk score generated successfully.
+          headers:
+            X-Trace-Id:
+              description: Identifier for correlating support inquiries.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScoreResponse'
+              examples:
+                allow:
+                  summary: Allowed transaction with low risk
+                  value:
+                    risk_score: 12
+                    risk_level: low
+                    decision: allow
+                    explanations:
+                      - "Trusted device with consistent behavior"
+                    confidence: 0.93
+                    policy_triggered: []
+                    trace_id: "trace_01HGFXG6S8P0P3"
+                    latency_ms: 2
+                challenge:
+                  summary: Challenge decision with medium risk
+                  value:
+                    risk_score: 64
+                    risk_level: medium
+                    decision: challenge
+                    explanations:
+                      - "New payee + amount anomaly"
+                      - "Velocity spike past 24h"
+                    confidence: 0.81
+                    policy_triggered:
+                      - "policy_new_payee_anomaly"
+                    trace_id: "trace_01HGFXJ7T3ND4K"
+                    latency_ms: 3
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /v1/batch/score:
+    post:
+      tags: [Scoring]
+      summary: Submit a batch of transactions for asynchronous scoring.
+      description: |
+        Accepts arrays of transaction payloads or newline-delimited JSON files for asynchronous
+        processing. Returns an ingestion receipt and a callback URL or polling token for
+        retrieving results.
+      operationId: submitBatch
+      security:
+        - OAuth2ClientCredentials: []
+        - ApiKeyAuth: []
+        - MutualTLS: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchScoreRequest'
+            examples:
+              arrayPayload:
+                summary: Inline array batch submission
+                value:
+                  batch_id: "batch_20240514_001"
+                  mode: inline
+                  transactions:
+                    - txn_id: "txn_01"
+                      timestamp: "2024-05-14T08:00:00Z"
+                      amount:
+                        currency: "USD"
+                        value: 499.0
+                      context: transfer
+                      counterparty_id: "hash_payee_A"
+                      payer_id: "hash_payer_A"
+                      device:
+                        device_id: "hash_device_A"
+                        ip_partial: "192.0.2.0/26"
+                        geo_coarse: "US-NY"
+                      channel: api
+                    - txn_id: "txn_02"
+                      timestamp: "2024-05-14T08:00:05Z"
+                      amount:
+                        currency: "USD"
+                        value: 3250.0
+                      context: invoice
+                      counterparty_id: "hash_vendor_B"
+                      payer_id: "hash_payer_A"
+                      device:
+                        device_id: "hash_device_B"
+                        ip_partial: "192.0.2.64/26"
+                        geo_coarse: "US-NY"
+                      channel: api
+          multipart/form-data:
+            schema:
+              type: object
+              required: [batch_id, mode, file]
+              properties:
+                batch_id:
+                  type: string
+                mode:
+                  type: string
+                  enum: [file]
+                file:
+                  type: string
+                  format: binary
+            encoding:
+              file:
+                contentType: application/x-ndjson
+                headers:
+                  Content-Hash:
+                    description: SHA-256 hash of the uploaded file for integrity verification.
+                    schema:
+                      type: string
+      responses:
+        '202':
+          description: Batch accepted for processing.
+          headers:
+            Retry-After:
+              description: Suggested polling interval in seconds.
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchSubmissionResponse'
+              examples:
+                accepted:
+                  summary: Batch accepted response
+                  value:
+                    batch_id: "batch_20240514_001"
+                    status: accepted
+                    callback_url: "https://sandbox.api.example.com/v1/events/batch_20240514_001"
+                    expires_at: "2024-05-14T08:15:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                tooLarge:
+                  value:
+                    error_code: PAYLOAD_TOO_LARGE
+                    message: "Batch size exceeds allowed limit of 10,000 records."
+                    remediation: "Reduce the batch or switch to file upload mode."
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /v1/events/{id}:
+    get:
+      tags: [Events]
+      summary: Fetch a specific decision record or batch result manifest.
+      description: |
+        Retrieves the decision details for a previously scored transaction or the manifest of
+        a completed batch submission. Sandbox results are retained for 7 days, production for 90 days.
+      operationId: getEvent
+      security:
+        - OAuth2ClientCredentials: []
+        - ApiKeyAuth: []
+        - MutualTLS: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Transaction ID, trace ID, or batch identifier.
+      responses:
+        '200':
+          description: Decision details found.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ScoreResponse'
+                  - $ref: '#/components/schemas/BatchResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Decision not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missing:
+                  value:
+                    error_code: NOT_FOUND
+                    message: "No decision found for id trace_123."
+                    remediation: "Confirm the identifier and retention window."
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /v1/health:
+    get:
+      tags: [Operations]
+      summary: Retrieve service status and latency metrics.
+      operationId: getHealth
+      security: []
+      responses:
+        '200':
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '503':
+          description: Service degraded or unavailable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                degraded:
+                  value:
+                    error_code: SERVICE_UNAVAILABLE
+                    message: "Latency above SLA thresholds."
+                    remediation: "Retry with exponential backoff or failover."
+  /v1/schema:
+    get:
+      tags: [Operations]
+      summary: Download the latest machine-readable API schema.
+      description: Returns the OpenAPI 3.1 specification for integration automation.
+      operationId: getSchema
+      security: []
+      responses:
+        '200':
+          description: Schema returned successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Serialized OpenAPI document.
+            application/yaml:
+              schema:
+                type: string
+components:
+  securitySchemes:
+    OAuth2ClientCredentials:
+      type: oauth2
+      description: OAuth 2.0 client credentials grant.
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/oauth2/token
+          scopes:
+            score: Submit transactions for scoring.
+            events: Retrieve decision history.
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+      description: Environment-scoped API key issued per client.
+    MutualTLS:
+      type: mutualTLS
+      description: Optional mutual TLS for enterprise tenants.
+  schemas:
+    Amount:
+      type: object
+      required: [currency, value]
+      properties:
+        currency:
+          type: string
+          pattern: "^[A-Z]{3}$"
+          description: ISO 4217 currency code.
+        value:
+          type: number
+          format: double
+          description: Monetary value in major units.
+    Device:
+      type: object
+      required: [device_id]
+      properties:
+        device_id:
+          type: string
+          description: Hashed device identifier.
+        ip_partial:
+          type: string
+          description: Partially masked IP address or subnet.
+        geo_coarse:
+          type: string
+          description: Country or region code.
+    Signals:
+      type: object
+      additionalProperties: true
+      description: Optional behavioral metrics or derived features.
+      properties:
+        keystroke_variance:
+          type: number
+          format: float
+        velocity_24h_bucket:
+          type: string
+        past_reversal_rate:
+          type: number
+          format: float
+    ScoreRequest:
+      type: object
+      required: [txn_id, timestamp, amount, context, counterparty_id, payer_id, device, channel]
+      properties:
+        txn_id:
+          type: string
+          description: Client-side transaction identifier.
+        timestamp:
+          type: string
+          format: date-time
+        amount:
+          $ref: '#/components/schemas/Amount'
+        context:
+          type: string
+          enum: [transfer, card, invoice, defi_sign, wallet_send, other]
+        counterparty_id:
+          type: string
+          description: Hashed identifier for counterparty.
+        payer_id:
+          type: string
+          description: Hashed identifier for payer.
+        device:
+          $ref: '#/components/schemas/Device'
+        signals:
+          $ref: '#/components/schemas/Signals'
+        channel:
+          type: string
+          enum: [web, ios, android, api]
+    ScoreResponse:
+      type: object
+      required: [risk_score, risk_level, decision, explanations, confidence, policy_triggered, trace_id, latency_ms]
+      properties:
+        risk_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        risk_level:
+          type: string
+          enum: [low, medium, high]
+        decision:
+          type: string
+          enum: [allow, challenge, block]
+        explanations:
+          type: array
+          items:
+            type: string
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        policy_triggered:
+          type: array
+          items:
+            type: string
+        trace_id:
+          type: string
+        latency_ms:
+          type: integer
+          minimum: 0
+    BatchScoreRequest:
+      type: object
+      required: [batch_id, mode]
+      properties:
+        batch_id:
+          type: string
+        mode:
+          type: string
+          enum: [inline, file]
+        callback_url:
+          type: string
+          format: uri
+          description: Optional webhook endpoint for asynchronous callbacks.
+        transactions:
+          type: array
+          description: Required when mode is inline.
+          items:
+            $ref: '#/components/schemas/ScoreRequest'
+    BatchSubmissionResponse:
+      type: object
+      required: [batch_id, status]
+      properties:
+        batch_id:
+          type: string
+        status:
+          type: string
+          enum: [accepted, processing, completed, failed]
+        callback_url:
+          type: string
+          format: uri
+        polling_token:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+    BatchResult:
+      type: object
+      required: [batch_id, status, results]
+      properties:
+        batch_id:
+          type: string
+        status:
+          type: string
+          enum: [processing, completed, failed, expired]
+        generated_at:
+          type: string
+          format: date-time
+        results:
+          type: array
+          items:
+            type: object
+            required: [txn_id, decision]
+            properties:
+              txn_id:
+                type: string
+              decision:
+                type: string
+                enum: [allow, challenge, block]
+              risk_score:
+                type: integer
+              risk_level:
+                type: string
+                enum: [low, medium, high]
+              explanations:
+                type: array
+                items:
+                  type: string
+              policy_triggered:
+                type: array
+                items:
+                  type: string
+              trace_id:
+                type: string
+    HealthResponse:
+      type: object
+      required: [status, latency_ms, last_updated]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unavailable]
+        latency_ms:
+          type: object
+          properties:
+            p50:
+              type: number
+            p95:
+              type: number
+            p99:
+              type: number
+        region_status:
+          type: array
+          items:
+            type: object
+            properties:
+              region:
+                type: string
+              status:
+                type: string
+        last_updated:
+          type: string
+          format: date-time
+    ErrorResponse:
+      type: object
+      required: [error_code, message]
+      properties:
+        error_code:
+          type: string
+        message:
+          type: string
+        remediation:
+          type: string
+  responses:
+    BadRequest:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalidContext:
+              value:
+                error_code: INVALID_CONTEXT
+                message: "context must be one of transfer|card|invoice|defi_sign|wallet_send|other"
+                remediation: "Update the payload to use a supported context."
+    Unauthorized:
+      description: Authentication failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            missingAuth:
+              value:
+                error_code: UNAUTHORIZED
+                message: "Missing or invalid credentials."
+                remediation: "Ensure OAuth token or API key is present and active."
+    Forbidden:
+      description: Authenticated client lacks permission.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            scopeDenied:
+              value:
+                error_code: INSUFFICIENT_SCOPE
+                message: "The provided credentials are not scoped for scoring."
+                remediation: "Request the score scope from the API administrator."
+    RateLimitExceeded:
+      description: Rate limit exceeded.
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds until the limit resets.
+        X-RateLimit-Limit:
+          schema:
+            type: integer
+        X-RateLimit-Remaining:
+          schema:
+            type: integer
+        X-RateLimit-Reset:
+          schema:
+            type: integer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            throttled:
+              value:
+                error_code: RATE_LIMITED
+                message: "Too many requests."
+                remediation: "Throttle requests or contact support for higher quotas."
+    ServerError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            generic:
+              value:
+                error_code: INTERNAL_ERROR
+                message: "Unexpected error occurred."
+                remediation: "Retry with exponential backoff or contact support if persistent."

--- a/docs/quickstart-snippets.md
+++ b/docs/quickstart-snippets.md
@@ -1,0 +1,187 @@
+# Quickstart Code Snippets
+
+Each snippet demonstrates how to call `POST /v1/score` in sandbox using minimal dependencies. Replace placeholders with real credentials.
+
+## cURL
+```bash
+curl --request POST "https://sandbox.api.example.com/v1/score" \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "txn_id": "txn_quickstart_001",
+    "timestamp": "2024-05-14T12:30:00Z",
+    "amount": { "currency": "USD", "value": 120.5 },
+    "context": "transfer",
+    "counterparty_id": "hash_payee_demo",
+    "payer_id": "hash_payer_demo",
+    "device": {
+      "device_id": "hash_device_cli",
+      "ip_partial": "198.51.100.0/24",
+      "geo_coarse": "US-CA"
+    },
+    "channel": "api"
+  }'
+```
+
+## Node.js (fetch)
+```javascript
+import fetch from "node-fetch";
+
+const payload = {
+  txn_id: "txn_quickstart_001",
+  timestamp: new Date().toISOString(),
+  amount: { currency: "USD", value: 120.5 },
+  context: "transfer",
+  counterparty_id: "hash_payee_demo",
+  payer_id: "hash_payer_demo",
+  device: {
+    device_id: "hash_device_js",
+    ip_partial: "198.51.100.0/24",
+    geo_coarse: "US-CA"
+  },
+  channel: "web"
+};
+
+const response = await fetch("https://sandbox.api.example.com/v1/score", {
+  method: "POST",
+  headers: {
+    "Authorization": `Bearer ${process.env.ACCESS_TOKEN}`,
+    "Content-Type": "application/json"
+  },
+  body: JSON.stringify(payload)
+});
+
+const result = await response.json();
+console.log(result.decision, result.explanations);
+```
+
+## Python (requests)
+```python
+import os
+import requests
+from datetime import datetime, timezone
+
+payload = {
+    "txn_id": "txn_quickstart_001",
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "amount": {"currency": "USD", "value": 120.5},
+    "context": "transfer",
+    "counterparty_id": "hash_payee_demo",
+    "payer_id": "hash_payer_demo",
+    "device": {
+        "device_id": "hash_device_py",
+        "ip_partial": "198.51.100.0/24",
+        "geo_coarse": "US-CA"
+    },
+    "channel": "web"
+}
+
+resp = requests.post(
+    "https://sandbox.api.example.com/v1/score",
+    headers={
+        "Authorization": f"Bearer {os.environ['ACCESS_TOKEN']}",
+        "Content-Type": "application/json",
+    },
+    json=payload,
+    timeout=3
+)
+resp.raise_for_status()
+print(resp.json()["decision"])
+```
+
+## Java (HTTP Client)
+```java
+var client = java.net.http.HttpClient.newHttpClient();
+var payload = """
+{
+  \"txn_id\": \"txn_quickstart_001\",
+  \"timestamp\": \"2024-05-14T12:30:00Z\",
+  \"amount\": { \"currency\": \"USD\", \"value\": 120.5 },
+  \"context\": \"transfer\",
+  \"counterparty_id\": \"hash_payee_demo\",
+  \"payer_id\": \"hash_payer_demo\",
+  \"device\": {
+    \"device_id\": \"hash_device_java\",
+    \"ip_partial\": \"198.51.100.0/24\",
+    \"geo_coarse\": \"US-CA\"
+  },
+  \"channel\": \"web\"
+}
+""";
+
+var request = java.net.http.HttpRequest.newBuilder()
+    .uri(java.net.URI.create("https://sandbox.api.example.com/v1/score"))
+    .header("Authorization", "Bearer " + System.getenv("ACCESS_TOKEN"))
+    .header("Content-Type", "application/json")
+    .POST(java.net.http.HttpRequest.BodyPublishers.ofString(payload))
+    .build();
+
+var response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());
+```
+
+## Go
+```go
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "os"
+    "time"
+)
+
+type Amount struct {
+    Currency string  `json:"currency"`
+    Value    float64 `json:"value"`
+}
+
+type Device struct {
+    DeviceID  string `json:"device_id"`
+    IPPartial string `json:"ip_partial"`
+    GeoCoarse string `json:"geo_coarse"`
+}
+
+type ScoreRequest struct {
+    TxnID         string  `json:"txn_id"`
+    Timestamp     string  `json:"timestamp"`
+    Amount        Amount  `json:"amount"`
+    Context       string  `json:"context"`
+    Counterparty  string  `json:"counterparty_id"`
+    Payer         string  `json:"payer_id"`
+    Device        Device  `json:"device"`
+    Channel       string  `json:"channel"`
+}
+
+func main() {
+    payload := ScoreRequest{
+        TxnID:     "txn_quickstart_001",
+        Timestamp: time.Now().UTC().Format(time.RFC3339),
+        Amount:    Amount{Currency: "USD", Value: 120.5},
+        Context:   "transfer",
+        Counterparty: "hash_payee_demo",
+        Payer:     "hash_payer_demo",
+        Device: Device{
+            DeviceID:  "hash_device_go",
+            IPPartial: "198.51.100.0/24",
+            GeoCoarse: "US-CA",
+        },
+        Channel: "web",
+    }
+
+    body, _ := json.Marshal(payload)
+    req, _ := http.NewRequest(http.MethodPost, "https://sandbox.api.example.com/v1/score", bytes.NewReader(body))
+    req.Header.Set("Authorization", "Bearer "+os.Getenv("ACCESS_TOKEN"))
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        panic(err)
+    }
+    defer resp.Body.Close()
+
+    fmt.Println("Status:", resp.Status)
+}
+```


### PR DESCRIPTION
## Summary
- add OpenAPI 3.1 specification for the Sentinel Fraud Decisioning API
- outline documentation information architecture, content templates, and quickstart snippets
- provide example payload cards and Mermaid diagrams to visualize key flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd581f15b4832581770fb8e10de1bb